### PR TITLE
Fix drag & drop issue

### DIFF
--- a/Documentation/Documentation.csproj
+++ b/Documentation/Documentation.csproj
@@ -9,11 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Documentation</RootNamespace>
     <AssemblyName>Documentation</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TabControl/TabControl.cs
+++ b/TabControl/TabControl.cs
@@ -483,7 +483,9 @@ namespace Manina.Windows.Forms
             Tabs = new TabCollection(this);
             renderer = new TabControlRenderer(this);
             UpdateTabLayout();
+
         }
+
         #endregion
 
         #region Property Defaults
@@ -598,10 +600,13 @@ namespace Manina.Windows.Forms
         /// <param name="tab">The tab to calculate bounds for.</param>
         public Rectangle GetTextBounds(Tab tab) => GetViewOffsetBounds(tab.TextBounds);
         #endregion
-
+        
         #region Overriden Methods
         protected override void OnHandleCreated(EventArgs e)
         {
+            // Av 2019-11-22: Without this line, we can't drag & drop onto the control
+            base.OnHandleCreated(e);
+
             UpdateTabLayout();
             UpdatePages();
         }
@@ -613,7 +618,8 @@ namespace Manina.Windows.Forms
             UpdateTabLayout();
             UpdatePages();
         }
-
+        
+        
         protected override void OnMouseMove(MouseEventArgs e)
         {
             base.OnMouseMove(e);
@@ -673,7 +679,8 @@ namespace Manina.Windows.Forms
                     Invalidate();
             }
         }
-
+        
+        
         protected override void OnMouseUp(MouseEventArgs e)
         {
             base.OnMouseUp(e);
@@ -704,6 +711,7 @@ namespace Manina.Windows.Forms
             if (oldmouseDownTab != null || oldmouseDownScrollButton != ScrollButton.None)
                 Invalidate();
         }
+        
 
         protected override void OnMouseDoubleClick(MouseEventArgs e)
         {
@@ -720,11 +728,13 @@ namespace Manina.Windows.Forms
             if (hoveredTab != null)
                 OnTabMouseWheel(new TabMouseEventArgs(hoveredTab, e.Button, e.Clicks, e.Delta, e.Location));
         }
-
+        
+    
         protected override void OnPaint(PaintEventArgs e)
         {
             renderer.Render(e.Graphics);
         }
+        
 
         protected override void OnPageAdded(PageEventArgs e)
         {
@@ -751,6 +761,7 @@ namespace Manina.Windows.Forms
             EnsureVisible(SelectedTab);
         }
         #endregion
+    
 
         #region Helper Methods
         /// <summary>

--- a/TabControl/TabControl.csproj
+++ b/TabControl/TabControl.csproj
@@ -32,7 +32,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PagedControl, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PagedControl.2.2.0\lib\net35\PagedControl.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\PagedControl\PagedControl\bin\Release\PagedControl.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -90,6 +91,12 @@
     </Compile>
     <Compile Include="Tab.cs">
       <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="TempControl.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="TempControl.Designer.cs">
+      <DependentUpon>TempControl.cs</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/TabControl/TempControl.Designer.cs
+++ b/TabControl/TempControl.Designer.cs
@@ -1,0 +1,36 @@
+﻿namespace Manina.Windows.Forms
+{
+    partial class TempControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+        }
+
+        #endregion
+    }
+}

--- a/TabControl/TempControl.cs
+++ b/TabControl/TempControl.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace Manina.Windows.Forms
+{
+    public partial class TempControl : PagedControl
+    {
+        public TempControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/TabControlTest/TestForm.Designer.cs
+++ b/TabControlTest/TestForm.Designer.cs
@@ -28,37 +28,61 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
             this.tabControl1 = new Manina.Windows.Forms.TabControl();
             this.tab1 = new Manina.Windows.Forms.Tab();
-            this.tab3 = new Manina.Windows.Forms.Tab();
-            this.tab5 = new Manina.Windows.Forms.Tab();
             this.tab4 = new Manina.Windows.Forms.Tab();
+            this.tab5 = new Manina.Windows.Forms.Tab();
+            this.tab3 = new Manina.Windows.Forms.Tab();
             this.tab2 = new Manina.Windows.Forms.Tab();
             this.tab6 = new Manina.Windows.Forms.Tab();
             this.tab7 = new Manina.Windows.Forms.Tab();
             this.tab8 = new Manina.Windows.Forms.Tab();
             this.tab9 = new Manina.Windows.Forms.Tab();
             this.tab10 = new Manina.Windows.Forms.Tab();
+            this.tempControl1 = new Manina.Windows.Forms.TempControl();
+            this.page1 = new Manina.Windows.Forms.Page();
+            this.page2 = new Manina.Windows.Forms.Page();
             this.tabControl1.SuspendLayout();
+            this.tempControl1.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(760, 222);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.TabIndex = 1;
+            this.button1.Text = "drag";
+            this.button1.UseVisualStyleBackColor = true;
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(760, 271);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.TabIndex = 2;
+            this.button2.Text = "drop";
+            this.button2.UseVisualStyleBackColor = true;
             // 
             // tabControl1
             // 
+            this.tabControl1.AllowDrop = true;
             this.tabControl1.Controls.Add(this.tab1);
-            this.tabControl1.Controls.Add(this.tab3);
-            this.tabControl1.Controls.Add(this.tab5);
             this.tabControl1.Controls.Add(this.tab4);
+            this.tabControl1.Controls.Add(this.tab5);
+            this.tabControl1.Controls.Add(this.tab3);
             this.tabControl1.Controls.Add(this.tab2);
             this.tabControl1.Controls.Add(this.tab6);
             this.tabControl1.Controls.Add(this.tab7);
             this.tabControl1.Controls.Add(this.tab8);
             this.tabControl1.Controls.Add(this.tab9);
             this.tabControl1.Controls.Add(this.tab10);
-            this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Location = new System.Drawing.Point(0, 0);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.ShowCloseTabButtons = true;
-            this.tabControl1.Size = new System.Drawing.Size(626, 347);
+            this.tabControl1.Size = new System.Drawing.Size(659, 421);
             this.tabControl1.TabIndex = 0;
             this.tabControl1.TabLocation = ((Manina.Windows.Forms.TabLocation)((Manina.Windows.Forms.TabLocation.Near | Manina.Windows.Forms.TabLocation.Bottom)));
             // 
@@ -67,16 +91,16 @@
             this.tab1.Icon = global::TabControlTest.Properties.Resources.brick;
             this.tab1.Location = new System.Drawing.Point(1, 1);
             this.tab1.Name = "tab1";
-            this.tab1.Size = new System.Drawing.Size(551, 345);
+            this.tab1.Size = new System.Drawing.Size(657, 396);
             this.tab1.Text = "tab1";
             // 
-            // tab3
+            // tab4
             // 
-            this.tab3.Icon = global::TabControlTest.Properties.Resources.cd;
-            this.tab3.Location = new System.Drawing.Point(1, 1);
-            this.tab3.Name = "tab3";
-            this.tab3.Size = new System.Drawing.Size(624, 322);
-            this.tab3.Text = "tab3";
+            this.tab4.Icon = global::TabControlTest.Properties.Resources.clock;
+            this.tab4.Location = new System.Drawing.Point(1, 1);
+            this.tab4.Name = "tab4";
+            this.tab4.Size = new System.Drawing.Size(624, 322);
+            this.tab4.Text = "tab4";
             // 
             // tab5
             // 
@@ -86,13 +110,13 @@
             this.tab5.Size = new System.Drawing.Size(624, 322);
             this.tab5.Text = "tab5";
             // 
-            // tab4
+            // tab3
             // 
-            this.tab4.Icon = global::TabControlTest.Properties.Resources.clock;
-            this.tab4.Location = new System.Drawing.Point(1, 1);
-            this.tab4.Name = "tab4";
-            this.tab4.Size = new System.Drawing.Size(551, 345);
-            this.tab4.Text = "tab4";
+            this.tab3.Icon = global::TabControlTest.Properties.Resources.cd;
+            this.tab3.Location = new System.Drawing.Point(1, 1);
+            this.tab3.Name = "tab3";
+            this.tab3.Size = new System.Drawing.Size(624, 322);
+            this.tab3.Text = "tab3";
             // 
             // tab2
             // 
@@ -100,7 +124,7 @@
             this.tab2.Icon = global::TabControlTest.Properties.Resources.cake;
             this.tab2.Location = new System.Drawing.Point(1, 1);
             this.tab2.Name = "tab2";
-            this.tab2.Size = new System.Drawing.Size(551, 345);
+            this.tab2.Size = new System.Drawing.Size(624, 322);
             this.tab2.Text = "tab2";
             // 
             // tab6
@@ -115,14 +139,14 @@
             // 
             this.tab7.Location = new System.Drawing.Point(1, 1);
             this.tab7.Name = "tab7";
-            this.tab7.Size = new System.Drawing.Size(551, 345);
+            this.tab7.Size = new System.Drawing.Size(624, 322);
             this.tab7.Text = "tab7";
             // 
             // tab8
             // 
             this.tab8.Location = new System.Drawing.Point(1, 1);
             this.tab8.Name = "tab8";
-            this.tab8.Size = new System.Drawing.Size(551, 345);
+            this.tab8.Size = new System.Drawing.Size(657, 396);
             this.tab8.Text = "tab8";
             // 
             // tab9
@@ -139,15 +163,43 @@
             this.tab10.Size = new System.Drawing.Size(551, 345);
             this.tab10.Text = "tab10";
             // 
+            // tempControl1
+            // 
+            this.tempControl1.Controls.Add(this.page1);
+            this.tempControl1.Controls.Add(this.page2);
+            this.tempControl1.Location = new System.Drawing.Point(689, 16);
+            this.tempControl1.Name = "tempControl1";
+            this.tempControl1.Size = new System.Drawing.Size(300, 200);
+            this.tempControl1.TabIndex = 3;
+            // 
+            // page1
+            // 
+            this.page1.Location = new System.Drawing.Point(1, 1);
+            this.page1.Name = "page1";
+            this.page1.Size = new System.Drawing.Size(298, 198);
+            this.page1.Text = "Page 1";
+            // 
+            // page2
+            // 
+            this.page2.Location = new System.Drawing.Point(1, 1);
+            this.page2.Name = "page2";
+            this.page2.Size = new System.Drawing.Size(298, 198);
+            this.page2.Text = "Page 2";
+            // 
             // TestForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(626, 347);
+            this.ClientSize = new System.Drawing.Size(1012, 533);
+            this.Controls.Add(this.tempControl1);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button1);
             this.Controls.Add(this.tabControl1);
             this.Name = "TestForm";
             this.Text = "TabControl Test Form";
+            this.Load += new System.EventHandler(this.TestForm_Load);
             this.tabControl1.ResumeLayout(false);
+            this.tempControl1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -166,6 +218,11 @@
         private Manina.Windows.Forms.Tab tab8;
         private Manina.Windows.Forms.Tab tab9;
         private Manina.Windows.Forms.Tab tab10;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
+        private Manina.Windows.Forms.TempControl tempControl1;
+        private Manina.Windows.Forms.Page page1;
+        private Manina.Windows.Forms.Page page2;
     }
 }
 

--- a/TabControlTest/TestForm.cs
+++ b/TabControlTest/TestForm.cs
@@ -1,12 +1,93 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
 
 namespace TabControlTest
 {
     public partial class TestForm : Form
     {
+        public Rectangle dragBoxFromMouseDown;
+
         public TestForm()
         {
             InitializeComponent();
+
+            button1.MouseDown += Button1_MouseDown;
+            button1.MouseMove += Button1_MouseMove;
+
+            button2.AllowDrop = true;
+            button2.DragOver += Button2_DragOver;
+            button2.DragDrop += Button2_DragDrop;
+
+            tabControl1.AllowDrop = true;
+            tabControl1.DragOver += TabControl1_DragOver;
+            tabControl1.DragDrop += TabControl1_DragDrop;
+
+            tempControl1.AllowDrop = true;
+            tempControl1.DragOver += TabControl1_DragOver;
+            tempControl1.DragDrop += TabControl1_DragDrop;
+
+        }
+
+        private void TabControl1_DragDrop(object sender, DragEventArgs e)
+        {
+            Console.WriteLine("Drop!");
+        }
+
+        private void TabControl1_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effect = DragDropEffects.All;
+            Console.WriteLine("Drag Over {0}", sender);
+        }
+
+        private void Button2_DragDrop(object sender, DragEventArgs e)
+        {
+            Console.WriteLine("Drop!");
+        }
+
+        private void Button2_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effect = DragDropEffects.All;
+            Console.WriteLine("Drag Over");
+        }
+
+        private void Button1_MouseMove(object sender, MouseEventArgs e)
+        {
+            if ((e.Button & MouseButtons.Left) == MouseButtons.Left || (e.Button & MouseButtons.Right) == MouseButtons.Right)
+            {
+                // If the mouse moves outside the rectangle, start the drag.
+                if (dragBoxFromMouseDown != Rectangle.Empty &&
+                    !dragBoxFromMouseDown.Contains(e.X, e.Y))
+                {
+
+                    // Proceed with the drag and drop, passing in the list item.                    
+
+                    var dd = new DataObject();
+                    dd.SetText("Hello World");
+                    
+                    DragDropEffects dropEffect = button1.DoDragDrop(
+                        dd,
+                        DragDropEffects.Copy | DragDropEffects.Move);
+
+                }
+            }
+        }
+
+        private void Button1_MouseDown(object sender, MouseEventArgs e)
+        {
+            Size dragSize = SystemInformation.DragSize;
+
+            // Create a rectangle using the DragSize, with the mouse position being
+            // at the center of the rectangle.
+            dragBoxFromMouseDown = new Rectangle(new Point(e.X - (dragSize.Width / 2),
+                                                            e.Y - (dragSize.Height / 2)),
+                                dragSize);
+
+        }
+
+        private void TestForm_Load(object sender, System.EventArgs e)
+        {
+
         }
     }
 }


### PR DESCRIPTION
Sorry for the messy pull request -- ignore all the changes except the one in TabControl.cs:

            // Av 2019-11-22: Without this line, we can't drag & drop onto the control
            base.OnHandleCreated(e);

Without this line, the control will not accept drag/drop operations, which I needed in my application.

Thanks!